### PR TITLE
Workflow gathering for clone and view metrics

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -1,0 +1,32 @@
+name: Github Repo Statistics
+
+on:
+  schedule:
+    # Run this once per day, towards the end of the day for keeping the most
+    # recent data point most meaningful (hours are interpreted in UTC).
+    - cron: "0 23 * * *"
+  workflow_dispatch: # Allow for running this manually.
+
+jobs:
+  repostats:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-app-ocio-github-repo-statistics
+    steps:
+
+      - name: Get Github App token
+        if: github.ref == 'refs/heads/main'
+        id: generate_token
+        run: |
+          echo "${{ secrets.PRIVATE_KEY }}" > private.pem
+          result=$(npx github-app-installation-token \
+            --appId ${{ vars.APP_ID }} \
+            --installationId ${{ vars.INSTALLATION_ID }} \
+            --privateKeyLocation private.pem)
+          echo "TOKEN=$result" >> "$GITHUB_OUTPUT"
+
+      - name: run github repository stats
+        uses: jgehrcke/github-repo-stats@v1.4.2
+        with:
+          ghtoken: ${{ steps.generate_token.outputs.TOKEN }}
+          ghpagesprefix: https://cdcgov.github.io/


### PR DESCRIPTION
## Update

Adding a workflow to collect workflow metrics using [jgehrcke/github-repo-stats](https://github.com/jgehrcke/github-repo-stats). This is so that we can see clone / view counts over a longer time than the typical Github insights, which allows for only two weeks of data.