### PR TITLE
Fixing Github pages - getting rid of the prefix

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -29,4 +29,4 @@ jobs:
         uses: jgehrcke/github-repo-stats@v1.4.2
         with:
           ghtoken: ${{ steps.generate_token.outputs.TOKEN }}
-          ghpagesprefix: https://cdcgov.github.io/
+          ghpagesprefix: https://cdcgov.github.io


### PR DESCRIPTION
- Apparently the "prefix" cannot end with a slash, so removing that because the link won't work otherwise.