### PR TITLE
Adding a full prefix link

### DIFF
--- a/.github/workflows/stats.yml
+++ b/.github/workflows/stats.yml
@@ -29,4 +29,4 @@ jobs:
         uses: jgehrcke/github-repo-stats@v1.4.2
         with:
           ghtoken: ${{ steps.generate_token.outputs.TOKEN }}
-          ghpagesprefix: https://cdcgov.github.io
+          ghpagesprefix: https://cdcgov.github.io/Opioid_SUD_MHI_MedCodes


### PR DESCRIPTION
## Update

- Reading the [https://github.com/jgehrcke/github-repo-stats](https://github.com/jgehrcke/github-repo-stats) documentation, it looks like I'm supposed to prepend the path like this to make the HTML link work. 
- Let's try that!